### PR TITLE
Fix: use released urfave cli

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -93,7 +93,7 @@ THE SOFTWARE.
 
 ---
 
-https://gopkg.in/urfave/cli.v2
+https://github.com/urfave/cli/v2
 
 MIT License
 

--- a/cmd/autocomplete/autocomplete.go
+++ b/cmd/autocomplete/autocomplete.go
@@ -10,7 +10,7 @@ import (
 
 	pvd "github.com/blinkhealth/go-config-yourself/pkg/provider"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // CommandAutocomplete is the function that autocompletes the main command

--- a/cmd/autocomplete/autocomplete_test.go
+++ b/cmd/autocomplete/autocomplete_test.go
@@ -8,9 +8,14 @@ import (
 
 	comp "github.com/blinkhealth/go-config-yourself/cmd/autocomplete"
 	fx "github.com/blinkhealth/go-config-yourself/internal/fixtures"
-
+	diff "github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 )
+
+var allFlags = []string{
+	"--verbose",
+	"--version",
+}
 
 func TestMain(m *testing.M) {
 	log.SetLevel(log.DebugLevel)
@@ -18,17 +23,15 @@ func TestMain(m *testing.M) {
 }
 
 func TestCommandAutoComplete(t *testing.T) {
-	out := fx.MockStdoutAndArgs()
+	mockedStdOut := fx.MockStdoutAndArgs()
 	comp.CommandAutocomplete(fx.MockCliCtx(nil))
+	output := mockedStdOut()
+	options := strings.Split(output, "\n")
+	expected := []string{"command", ""}
 
-	if out := out(); out != strings.Join(append(allFlags, "command\n"), "\n") {
-		t.Fatalf("Invalid output: %s", out)
+	if !diff.Equal(options, expected) {
+		t.Fatalf("Invalid output, got: %v, expected %v", options, expected)
 	}
-}
-
-var allFlags = []string{
-	"--verbose",
-	"--version",
 }
 
 func TestListProviderFlags(t *testing.T) {

--- a/cmd/before.go
+++ b/cmd/before.go
@@ -4,7 +4,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/pkg/file"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // The configfile instance for this command session

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -9,7 +9,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/cmd/autocomplete"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 			},
 		},
 		Action: get,
-		ShellComplete: func(ctx *cli.Context) {
+		BashComplete: func(ctx *cli.Context) {
 			if ctx.NArg() == 0 {
 				os.Exit(1)
 			}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/mitchellh/go-wordwrap"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh/terminal"
 	cli "github.com/urfave/cli/v2"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var markdownCodeBlock = regexp.MustCompile("`([^`]+)`")

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -18,7 +18,7 @@ import (
 	"github.com/mitchellh/go-wordwrap"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 var markdownCodeBlock = regexp.MustCompile("`([^`]+)`")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -9,7 +9,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/pkg/file"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 func init() {
@@ -25,7 +25,7 @@ func init() {
 		Description: description,
 		Flags:       KeyFlags,
 		Action:      initAction,
-		ShellComplete: func(ctx *cli.Context) {
+		BashComplete: func(ctx *cli.Context) {
 			autocomplete.ListProviderFlags(ctx)
 			os.Exit(1)
 		},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/cmd/autocomplete"
 	"github.com/blinkhealth/go-config-yourself/cmd/util"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 var App = &cli.App{
@@ -41,9 +41,9 @@ var App = &cli.App{
 		}
 		return nil
 	},
-	Commands:              []*cli.Command{},
-	EnableShellCompletion: true,
-	ShellComplete:         autocomplete.CommandAutocomplete,
+	Commands:             []*cli.Command{},
+	EnableBashCompletion: true,
+	BashComplete:         autocomplete.CommandAutocomplete,
 	CommandNotFound: func(ctx *cli.Context, name string) {
 		// Show help, then error out
 		_ = cli.ShowAppHelp(ctx)
@@ -69,7 +69,7 @@ func Main(version string) {
 		Usage:   "print the version",
 	}
 
-	cli.InitCompletionFlag.Hidden = true
+	// cli.BashCompletionFlag = true
 
 	cli.HelpPrinter = helpPrinter
 	cli.AppHelpTemplate = helpTemplateApp

--- a/cmd/rekey.go
+++ b/cmd/rekey.go
@@ -8,7 +8,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/pkg/file"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 func init() {
@@ -22,7 +22,7 @@ func init() {
 		ArgsUsage:   "CONFIG_FILE",
 		Action:      rekey,
 		Flags:       KeyFlags,
-		ShellComplete: func(ctx *cli.Context) {
+		BashComplete: func(ctx *cli.Context) {
 			if ctx.NArg() == 0 {
 				if !autocomplete.ListProviderFlags(ctx) {
 					return

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -12,7 +12,7 @@ import (
 	"github.com/blinkhealth/go-config-yourself/internal/input"
 	"github.com/blinkhealth/go-config-yourself/pkg/file"
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 func init() {
@@ -50,7 +50,7 @@ func init() {
 				Aliases: []string{"i"},
 			},
 		},
-		ShellComplete: func(ctx *cli.Context) {
+		BashComplete: func(ctx *cli.Context) {
 			if ctx.NArg() == 0 {
 				autocomplete.ListAllFlags(ctx)
 				if !ctx.IsSet("input-file") {

--- a/cmd/util/key-arguments.go
+++ b/cmd/util/key-arguments.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // GetKeyArguments reads arguments from the command line and parses them into flags

--- a/cmd/util/output.go
+++ b/cmd/util/output.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	file "github.com/blinkhealth/go-config-yourself/pkg/file"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // SerializeAndWrite a config file to disk

--- a/cmd/util/provider-flags.go
+++ b/cmd/util/provider-flags.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	pvd "github.com/blinkhealth/go-config-yourself/pkg/provider"
-	cli "gopkg.in/urfave/cli.v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 // providerFlag implements urfave/cli.v2/Generic

--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,16 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.25.36
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/google/go-cmp v0.3.1
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/muesli/crunchy v0.0.0-20191002192727-c0afa2da818f
 	github.com/proglottis/gpgme v0.1.0
 	github.com/sirupsen/logrus v1.4.2
+	github.com/urfave/cli/v2 v2.0.0
 	github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 // indirect
 	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
-	gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8
 	gopkg.in/yaml.v3 v3.0.0-20191107175235-0b070bb63a18
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/gometalinter v2.0.11+incompatible h1:ENdXMllZNSVDTJUUVIzBW9CSEpntTrQa76iRsEFLX/M=
 github.com/alecthomas/gometalinter v2.0.11+incompatible/go.mod h1:qfIpQGGz3d+NmgyPBqv+LSh50emm1pt72EtcX2vKYQk=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
@@ -12,10 +13,14 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3 h1:I4BOK3PBMjhWfQM2zPJKK7lOBGsrsvOB7kBELP33hiE=
 github.com/golang/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf h1:7+FW5aGwISbqUtkfmIpZJGRgNFg2ioYPvFaUxdqpDsg=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/gordonklaus/ineffassign v0.0.0-20180909121442-1003c8bd00dc h1:cJlkeAx1QYgO5N80aF5xRGstVsRQwgLR7uA2FnP1ZjY=
@@ -47,6 +52,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/proglottis/gpgme v0.1.0 h1:s9YZv14B4Qgu9RkrCk87JkMVGOcSyraJEDPnXGBrjqc=
 github.com/proglottis/gpgme v0.1.0/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -54,6 +63,10 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9 h1:vY5WqiEon0ZSTGM3ayVVi+twaHKHDFUVloaQ/wug9/c=
 github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9/go.mod h1:q+QjxYvZ+fpjMXqs+XEriussHjSYqeXVnAdSV1tkMYk=
+github.com/urfave/cli/v2 v2.0.0-20180128182452-d3ae77c26ac8 h1:Ggy3mWN4l3PUFPfSG0YB3n5fVYggzysUmiUQ89SnX6Y=
+github.com/urfave/cli/v2 v2.0.0-20180128182452-d3ae77c26ac8/go.mod h1:cKXr3E0k4aosgycml1b5z33BVV6hai1Kh7uDgFOkbcs=
+github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
+github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
@@ -80,7 +93,6 @@ gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mo
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8 h1:Ggy3mWN4l3PUFPfSG0YB3n5fVYggzysUmiUQ89SnX6Y=
-gopkg.in/urfave/cli.v2 v2.0.0-20180128182452-d3ae77c26ac8/go.mod h1:cKXr3E0k4aosgycml1b5z33BVV6hai1Kh7uDgFOkbcs=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20191107175235-0b070bb63a18 h1:VaaR1yHVgJQaTGM1DXum4OU6He6gaZXAPII85hHgSzQ=
 gopkg.in/yaml.v3 v3.0.0-20191107175235-0b070bb63a18/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/fixtures/mock.go
+++ b/internal/fixtures/mock.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/proglottis/gpgme"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/urfave/cli.v2"
+	"github.com/urfave/cli/v2"
 )
 
 type mockKey string


### PR DESCRIPTION
## Context

[urfave/cli](https://github.com/urfave/cli) released yesterday the final 2.0 tag and all tests broke.

## Description of changes

- switch to `github.com` packages instead of `gopkg.in` as that's what is mentioned in their docs
- use [google/go-cmp](github.com/google/go-cmp/cmp) to diff slices in autocomplete test