### PR TITLE
Fix broken builds, build with golang 0.12.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build: dist build-deps dist/gcy-macos-amd64.tgz dist/gcy-linux-amd64.tgz debian
 build-xgo: dist
 	# produce debug-symbol stripped binaries
 	$(GOBIN)/xgo --image xgo \
-		--targets 'linux/amd64 linux/arm-7 darwin-10.10/amd64'
+		--targets 'linux/amd64 linux/arm-7 darwin-10.10/amd64' \
 		--out 'dist/gcy' \
 		--ldflags "-s -w -X main.version=$(shell sed 's/^v//' dist/VERSION)" \
 		$(ROOT_DIR)

--- a/bin/build/Dockerfile
+++ b/bin/build/Dockerfile
@@ -1,4 +1,5 @@
-FROM techknowlogick/xgo:go-1.11.8
+FROM techknowlogick/xgo:go-1.12.x
+# see https://github.com/techknowlogick/xgo
 # Used by go-config-yourself to cross compile to MacOS and Linux from CircleCI
 
 ENV GPGME_VERSION "1.13.0"
@@ -29,3 +30,5 @@ COPY gpgme.sh /build-libs
 RUN /build-libs/gpgme.sh
 # clean up
 RUN rm -rf /build-libs
+# specify correct prefix for osx cgo builds
+RUN sed -i 's|GOOS=darwin GOARCH=amd64|GOOS=darwin GOARCH=amd64 CGO_CFLAGS="-I/usr/local/osx-ndk-x86/SDK/MacOSX10.11.sdk/usr/include" CGO_LDFLAGS="-L/usr/local/osx-ndk-x86/SDK/MacOSX10.11.sdk/usr/lib"|' /build.sh

--- a/bin/build/gpgme.sh
+++ b/bin/build/gpgme.sh
@@ -4,7 +4,7 @@
 set -o errexit
 
 BUILD_ROOT="/build-libs"
-targets=(linux darwin arm)
+targets=(linux arm darwin)
 gpgme="$BUILD_ROOT/gpgme"
 libs=("$BUILD_ROOT/libgpg-error" "$BUILD_ROOT/libassuan")
 for target in "${targets[@]}"; do
@@ -55,6 +55,9 @@ buildEnv() {
       export CPP="arm-linux-gnueabihf-cpp-5"
       export STRIP="arm-linux-gnueabihf-strip"
       export RANLIB="arm-linux-gnueabihf-ranlib"
+      ;;
+    default)
+      >&2 echo "Unknown target $1"
   esac
   export HOST
 }


### PR DESCRIPTION
## Context

Turns out I broke the builds with #18 due to a missing backslash. I learned a bit more about `CFLAGS` and `LDFLAGS` which let us specify the paths to built libraries and included headers, I suspect by default it corresponds to [`/usr(/local)?`](https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout). I set these to the corresponding path for [osxcross](https://github.com/tpoechtrager/osxcross) (the cross-compilation toolchain for MacOS that is used by [xgo](https://github.com/tpoechtrager/osxcross)), `/usr/local/osx-ndk-x86/SDK/MacOSX10.11.sdk/usr`; these static libraries and headers are dropped there after building in `bin/build/gpgme.sh`. Same thing happens with ARM, however, it seems the toolchain for linux handles this automagically.

## Description of changes

- Build with golang 0.12x