### PR TITLE
Output nice errors on rekeying, prevent empty region during cross-provider rekey

### DIFF
--- a/cmd/rekey.go
+++ b/cmd/rekey.go
@@ -64,7 +64,7 @@ func rekey(ctx *cli.Context) (err error) {
 
 	newConfig, err := originalConfig.Rekey(newProvider, args)
 	if err != nil {
-		return Exit(ExitCodeToolError, 3)
+		return Exit(err, ExitCodeToolError)
 	}
 
 	if err := util.SerializeAndWrite(fileName, newConfig); err != nil {

--- a/pkg/crypto/kms/service.go
+++ b/pkg/crypto/kms/service.go
@@ -54,6 +54,9 @@ func createAWSSession(region string) (sess *session.Session, config *aws.Config)
 }
 
 func newKMSService(region string) (svc *kmsService) {
+	if region == "" {
+		region = "us-east-1"
+	}
 	awsSess, awsConfig := createAWSSession(region)
 
 	return &kmsService{


### PR DESCRIPTION
## Context

`gcy rekey` across providers fails due to empty region initialization with the KMS key provider, and errors were not being printed properly due to bad passing of arguments.

## Description of changes

- initialize the KMS service with the 'us-east-1' region if no region is set
- print `rekey` errors correctly
