### PR TITLE
fix: Github homebrew release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           export VERSION="${GITHUB_REF##*/}"
           export SHASUM="$(curl --silent --fail --show-error -L "$download_url/$VERSION/gcy-macos-amd64.shasum")"
           export PACKAGE="$DOWNLOAD_URL/$VERSION/gcy-macos-amd64.tgz"
-          export DASHED_VERSION "${VERSION//./-}"
+          export DASHED_VERSION="${VERSION//./-}"
 
           echo "::set-env name=VERSION::$VERSION"
           echo "::set-env name=DASHED_VERSION::$DASHED_VERSION"


### PR DESCRIPTION
## Context

Homebrew releases are failing due to a missing `=` on an export step during the github action workflow.

## Description of changes

- add missing '=' to export