### PR TITLE
fix: prevent panic on bonafide nil values

### DIFF
--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -68,7 +68,10 @@ func (cfg *ConfigFile) Get(keyPath string) (value interface{}, err error) {
 		return nil, err
 	}
 
-	value, err = decryptNode(node, cfg.crypto)
+	// nodes can be nil when the key exists and its value is nil
+	if node != nil {
+		value, err = decryptNode(node, cfg.crypto)
+	}
 	return
 }
 


### PR DESCRIPTION
## Context

Running `set` on a file with a corresponding `defaults` file will panic if the desired key exists and its value is actually `nil`. Props @anilnanda-blink for finding the bug 🐛 

Panic looks like:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4544ca8]
goroutine 1 [running]:
internal/yaml.(*Tree).IsMap(...)
	/source/internal/yaml/yaml.go:185
pkg/file.decryptNode(0x0, 0x48e9400, 0xc0005b02c0, 0x460e2e0, 0xc000010148, 0x0, 0x0)
	/source/pkg/file/secrets.go:36 +0x38
pkg/file.(*ConfigFile).Get(0xc00026eae0, 0x7ffeefbff629, 0x16, 0x0, 0x0, 0x1, 0x1)
	/source/pkg/file/file.go:71 +0x21f
cmd.updateDefaultsFile(0x7ffeefbff620, 0x8, 0x7ffeefbff629, 0x16)
	/source/cmd/set.go:148 +0x3d5
cmd.set(0xc000286080, 0x0, 0x0)
	/source/cmd/set.go:127 +0x673
github.com/urfave/cli/v2.(*Command).Run(0xc0001138c0, 0xc00021a440, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.0.1-0.20191201095458-2dc008dada79/command.go:161 +0x3ee
github.com/urfave/cli/v2.(*App).Run(0x4d03800, 0xc000020080, 0x4, 0x4, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.0.1-0.20191201095458-2dc008dada79/app.go:294 +0x6cb
cmd.Main(0x48c9944, 0x5)
	/source/cmd/main.go:80 +0x213
main.main()
	/source/main.go:20 +0x39
```

## Description of changes

Prevent `pkg/file#Get` from decrypting `nil` values, returning them as is.