### PR TITLE
fix: More nil value handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Update homebrew formula locally
         run: |
-          sed -i -E "s|url .*|url '${PACKAGE}'|;"go-config-yourself.rb
+          sed -i -E "s|url .*|url '${PACKAGE}'|" go-config-yourself.rb
           sed -i -E "s|sha256 .*|sha256 '${SHASUM}'|" go-config-yourself.rb
           sed -i -E "s|version .*|version '${VERSION//v/}'|" go-config-yourself.rb
 

--- a/pkg/file/secrets.go
+++ b/pkg/file/secrets.go
@@ -33,6 +33,10 @@ func (cryptoDisabledError) Error() string {
 }
 
 func decryptNode(node *yaml.Tree, provider pvd.Crypto) (interface{}, error) {
+	if node == nil {
+		return nil, nil
+	}
+
 	if node.IsMap() {
 		if node.IsEncrypted() {
 			if provider == nil || !provider.Enabled() {


### PR DESCRIPTION
## Context

PR #23 introduced an issue of panicking while trying to decrypt nil values, which `pkg/file/secrets#decryptNode` did not handle.

## Description of changes

- Return `nil` early from `decryptNode` to avoid a `invalid memory address or nil pointer dereference` panic.
- fix failing sed expression during homebrew release github action

Full stack trace:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4545858]

goroutine 1 [running]:
github.com/blinkhealth/go-config-yourself/internal/yaml.(*Tree).IsMap(...)
	/source/internal/yaml/yaml.go:185
github.com/blinkhealth/go-config-yourself/pkg/file.secretsForNode(0x0, 0xc000731180, 0x1d, 0x2, 0x2, 0xc000731180)
	/source/pkg/file/secrets.go:114 +0x58
github.com/blinkhealth/go-config-yourself/pkg/file.secretsForNode(0xc000264d40, 0xc00002bef0, 0x7, 0x3, 0xc000635460, 0x2)
	/source/pkg/file/secrets.go:128 +0x2bc
github.com/blinkhealth/go-config-yourself/pkg/file.secretsForNode(0xc0001f9d40, 0x0, 0x0, 0x0, 0x11, 0xc000342800)
	/source/pkg/file/secrets.go:128 +0x2bc
github.com/blinkhealth/go-config-yourself/pkg/file.(*ConfigFile).ListSecrets(...)
	/source/pkg/file/file.go:159
github.com/blinkhealth/go-config-yourself/pkg/file.(*ConfigFile).Rekey(0xc0001e3cb0, 0xc00002b930, 0x3, 0xc0001e3da0, 0x3, 0x0, 0x0)
	/source/pkg/file/file.go:106 +0x370
github.com/blinkhealth/go-config-yourself/cmd.rekey(0xc0000c01c0, 0x6, 0x8)
	/source/cmd/rekey.go:65 +0x1ff
github.com/urfave/cli/v2.(*Command).Run(0xc0000f5680, 0xc000208540, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.0.1-0.20191201095458-2dc008dada79/command.go:161 +0x3ee
github.com/urfave/cli/v2.(*App).Run(0x4d03800, 0xc000020030, 0x3, 0x3, 0x0, 0x0)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.0.1-0.20191201095458-2dc008dada79/app.go:294 +0x6cb
github.com/blinkhealth/go-config-yourself/cmd.Main(0x48c9944, 0x5)
	/source/cmd/main.go:80 +0x213
main.main()
	/source/main.go:20 +0x39
```