### PR TITLE
chore: run linter, fix warnings, add badges

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,14 @@ issues:
     - text: error strings should not be capitalized
       linters:
         - golint
+    # todo: use stretchr/testify to abstract cyclomatic complexity under the rug
+    - path: _test\.go
+      linters:
+        - gocyclo
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
 
 linters:
   fast: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,35 @@
+# cilint author made some choices I don't like, such as
+# no comments for exported vars (which make docs nice )
+
 issues:
+  exclude-use-default: false
   exclude:
     - ST1005
+    - G104
+    - G304
+  exclude-rules:
+    - text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+      linters:
+        - errcheck
+    - text: error strings should not be capitalized
+      linters:
+        - golint
+
 linters:
-  fast: true
+  fast: false
   enable:
     - goconst
     - gocritic
     - gocyclo
+    - gofmt
+    - golint
     - goimports
-    - stylecheck
-    - interfacer
     - gosec
+    - interfacer
     - maligned
     - misspell
     - prealloc
     - scopelint
+    - stylecheck
     - unconvert
     - unparam
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # go-config-yourself
 
+[![Latest stable release](https://img.shields.io/github/v/release/blinkhealth/go-config-yourself?sort=semver)](https://github.com/blinkhealth/go-config-yourself/releases/latest)
 [![Test status](https://github.com/blinkhealth/go-config-yourself/workflows/Tests/badge.svg)](https://github.com/blinkhealth/go-config-yourself/actions?query=branch%3Amaster+event%3Apush)
 [![Coverage Status](https://coveralls.io/repos/github/blinkhealth/go-config-yourself/badge.svg?branch=master)](https://coveralls.io/github/blinkhealth/go-config-yourself?branch=master)
+[![Go report card](https://goreportcard.com/badge/github.com/blinkhealth/go-config-yourself)](https://goreportcard.com/report/github.com/blinkhealth/go-config-yourself)
 
 A secrets-management CLI tool and language-specific runtimes to deal with everyday application configuration right from your repository. **go-config-yourself** aims to simplify the management of secrets from your terminal and their use within application code. Configuration files are kept as human-readable as possible, so change management is easily achievable in any version-control system (like git).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,11 +18,12 @@ import (
 	cli "github.com/urfave/cli/v2"
 )
 
+// App is a cli.App skeleton
 var App = &cli.App{
 	Name:  "gcy",
 	Usage: "gcy COMMAND CONFIG_FILE [KEYPATH]",
 	Authors: []*cli.Author{
-		&cli.Author{
+		{
 			Name:  "Blink Health",
 			Email: "opensource@blinkhealth.com",
 		},
@@ -55,6 +56,8 @@ var App = &cli.App{
 		os.Exit(1)
 	},
 }
+
+// KeyFlags point to a list of cli flags for key-related operations
 var KeyFlags = util.KeyFlags()
 
 // Main main function for go-config-yourself

--- a/internal/datakey/datakey.go
+++ b/internal/datakey/datakey.go
@@ -28,7 +28,7 @@ type Service struct {
 	key []byte
 }
 
-// Fills a slice with random bytes
+// RandomBytes fills a slice with random bytes
 func RandomBytes(value *[]byte) error {
 	_, err := rand.Read(*value)
 	if err != nil {

--- a/internal/fixtures/loader.go
+++ b/internal/fixtures/loader.go
@@ -1,3 +1,4 @@
+// Package fixtures contains testing methods and data
 package fixtures
 
 import (

--- a/internal/fixtures/mock.go
+++ b/internal/fixtures/mock.go
@@ -16,7 +16,9 @@ import (
 type mockKey string
 
 const (
+	// MockKMSKey is what the key arn used by the test suite
 	MockKMSKey mockKey = "arn:aws:kms:us-east-1:000000000000:key/00000000-AAAA-1111-BBBB-CC22DD33EE44"
+	//MockGPGKey is the key name used by the test suite
 	MockGPGKey mockKey = "test-software@blinkhealth.com"
 )
 

--- a/pkg/crypto/kms/service.go
+++ b/pkg/crypto/kms/service.go
@@ -115,9 +115,9 @@ func (svc *kmsService) ListKeys() (keys []string, err error) {
 					if awsErr.Code() != "UnrecognizedClientException" {
 						listingErrors <- err
 						return
-					} else {
-						log.Warningf("Unable to query possibly disabled region %s for keys, ignoring", region)
 					}
+
+					log.Warningf("Unable to query possibly disabled region %s for keys, ignoring", region)
 				} else {
 					listingErrors <- fmt.Errorf("Error querying for keys in %s: %s", region, err)
 					return

--- a/pkg/crypto/kms/service_kms_mock.go
+++ b/pkg/crypto/kms/service_kms_mock.go
@@ -27,11 +27,11 @@ type mockKey struct {
 
 var BadCreds = awserr.New("NoCredentialProviders", "invalid-access-key", nil)
 var mockKeys = []*mockKey{
-	&mockKey{
+	{
 		id:     "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
 		errors: false,
 	},
-	&mockKey{
+	{
 		id:        "arn:aws:kms:us-east-1:111111111111:key/11111111-1111-1111-1111-111111111111",
 		errors:    true,
 		errorCode: "NoCredentialProviders",
@@ -113,7 +113,7 @@ func (m *mockKMSClient) ListAliasesWithContext(context aws.Context, input *awsKM
 	}
 	regionalKey := strings.Replace(mockKeys[0].id, "us-east-1", m.region, 1)
 	aliases := []*awsKMS.AliasListEntry{
-		&awsKMS.AliasListEntry{
+		{
 			AliasArn: &regionalKey,
 		},
 	}


### PR DESCRIPTION
## Context

[goreportcard](https://goreportcard.com/report/github.com/blinkhealth/go-config-yourself) and [`golangci-lint`](https://github.com/golangci/golangci-lint) were not agreeing on linting issues, `golangci-lint` needed some tweaks to match.

## Description of changes

- tweak `.golangci.yml` to match goreportcard
- add "version" and "goreportcard" badges