### PR TITLE
Feature: `get CONFIG_FILE .` to output whole file as json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ coverage:
 
 test-deps:
 	# install outside package dir so go.sum is not affected
-	cd / && GO111MODULE=auto go get -u gotest.tools/gotestsum github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd / && GO111MODULE=on go get -u gotest.tools/gotestsum github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # --------------
 # Build

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ gcy get CONFIG_FILE KEYPATH
 
 Outputs the plain-text value for `KEYPATH` in `CONFIG_FILE`.
 
-`KEYPATH` refers to a dot-delimited path to values, see `gcy help keypath` for examples.
+`KEYPATH` refers to a dot-delimited path to values, see `gcy help keypath` for examples. When `.` is passed as `KEYPATH`, the whole document will be returned.
 
-If the value at `KEYPATH` is a dictionary or a list, it will be encoded as JSON, with all of the encrypted values within decrypted. If no value `KEYPATH` exists, `gcy get` will fail with exit code 2.
+If the value at `KEYPATH` is a dictionary, list, or `.`, the resulting value will be encoded as JSON, with all of the encrypted values within decrypted. If no value `KEYPATH` exists, `gcy get` will fail with exit code 2.
 
 ```sh
 gcy get config-up-there.yml some.nested.object

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -16,9 +16,9 @@ func init() {
 	description := multiLineDescription(
 		"Outputs the plain-text value for `KEYPATH` in `CONFIG_FILE`.",
 
-		"`KEYPATH` refers to a dot-delimited path to values, see `gcy help keypath` for examples.",
+		"`KEYPATH` refers to a dot-delimited path to values, see `gcy help keypath` for examples. When `.` is passed as `KEYPATH`, the whole document will be returned.",
 
-		"If the value at `KEYPATH` is a dictionary or a list, it will be encoded as JSON, with all of the encrypted values within decrypted. If no value `KEYPATH` exists, `gcy get` will fail with exit code 2.",
+		"If the value at `KEYPATH` is a dictionary, list, or `.`, the resulting value will be encoded as JSON, with all of the encrypted values within decrypted. If no value `KEYPATH` exists, `gcy get` will fail with exit code 2.",
 	)
 
 	App.Commands = append(App.Commands, &cli.Command{
@@ -51,7 +51,13 @@ func init() {
 
 // Get a value from a config file
 func get(ctx *cli.Context) error {
-	value, err := configFile.Get(ctx.String("keypath"))
+	var value interface{}
+	var err error
+	if ctx.String("keypath") == "." {
+		value, err = configFile.GetAll()
+	} else {
+		value, err = configFile.Get(ctx.String("keypath"))
+	}
 
 	if err != nil {
 		return Exit(err, ExitCodeInputError)

--- a/test/cli/get.bats
+++ b/test/cli/get.bats
@@ -18,3 +18,9 @@ load "conftest"
   bc set $file newSecret <<<"a new secret"
   [[ "$(bc get $file newSecret)" == *'a new secret'* ]]
 }
+
+@test "get literal dot reads everything" {
+  file=$(fixture encrypted.kms)
+  [[ "$(bc get $file . | jq -r 'keys | length')" == '9' ]]
+  [[ "$(bc get $file . | openssl dgst -md5)" == '687d38244ad3eb2fd96cd93f4dafd012' ]]
+}


### PR DESCRIPTION
## Context

Hello friends, hope you're doing well. I've kept using this, as you can imagine. Turns out shell scripting is much nicer if we can decrypt the whole file in one go, as cy libraries already do. Been using this for a while, thought I'd share back.

## Description of changes

- uses `file.GetAll` if `ctx.String("keypath") == "."` during `get`
- adds integration test
- updates docs
